### PR TITLE
🚀 Гослинг спасает планеты: фикс тайлов, атмосферы и архитектурного отчаяния

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -1005,8 +1005,9 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
     /// <summary>
     /// Creates a simple planet setup for a map.
     /// </summary>
-    public void EnsurePlanet(EntityUid mapUid, BiomeTemplatePrototype biomeTemplate, int? seed = null,
-        MetaDataComponent? metadata = null, Color? mapLight = null, GasMixture? atmosphere = null)
+    /// public void EnsurePlanet(EntityUid mapUid, BiomeTemplatePrototype biomeTemplate, int? seed = null, MetaDataComponent? metadata = null, Color? mapLight = null)
+    public void EnsurePlanet(EntityUid mapUid, BiomeTemplatePrototype biomeTemplate, int? seed = null, //Corvax-Next
+        MetaDataComponent? metadata = null, Color? mapLight = null, GasMixture? atmosphere = null) //Corvax-Next
     {
         if (!Resolve(mapUid, ref metadata))
             return;
@@ -1039,15 +1040,22 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
 
         EnsureComp<SunShadowComponent>(mapUid);
         EnsureComp<SunShadowCycleComponent>(mapUid);
+        // var moles = new float[Atmospherics.AdjustedNumberOfGases];
+        // moles[(int)Gas.Oxygen] = 21.824779f;
+        // moles[(int)Gas.Nitrogen] = 82.10312f;
+
+        // var mixture = new GasMixture(moles, Atmospherics.T20C);
+
+        // _atmos.SetMapAtmosphere(mapUid, false, mixture);
         // Before: "Hardcoded moles like an absolute ape, never checking if there was already an atmosphere or not."
         // After: "Finally checks for existing atmosphere like someone with two brain cells. Still ugly, but at least less retarded."
-        GasMixture mixture;
+        GasMixture mixture; // Corvax-Next start
         var space = false;
         // This block is just a band-aid on top of a festering wound. If you pass in an atmosphere, we’ll use it,
         // but god forbid anyone document what the fuck 'space' is supposed to mean.
         // If you’re not using the parameter, we go on a wild goose chase looking for atmosphere components.
         // Why does everything in this codebase need a fucking 'if (something != null)'? Absolute pain.
-        if (atmosphere != null)
+        if (atmosphere != null) 
         {
             mixture = atmosphere;
         }
@@ -1066,7 +1074,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         }
         // Congratulations, we now set the map’s atmosphere with a space flag.
         // I’m sure this won’t break anything, but if it does, don’t blame me — blame the sadist who wrote the rest of this class.
-        _atmos.SetMapAtmosphere(mapUid, space, mixture);
+        _atmos.SetMapAtmosphere(mapUid, space, mixture); // Corvax-Next end
     }
 
     /// <summary>

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -57,8 +57,13 @@ public sealed class FloorTileSystem : EntitySystem
         if (component.OutputTiles == null)
             return;
 
-        // this looks a bit sussy but it might be because it needs to be able to place off of grids and expand them
-        var location = args.ClickLocation.AlignWithClosestGridTile();
+        // Jesus fucking Christ, this old code was an absolute disaster.
+        // Who the fuck wrote AlignWithClosestGridTile()? Did they ever even launch the fucking game?
+        // SnapToGrid at least makes sure we don’t place shit on the wrong grid when there are shuttles or other abominations stacked up.
+        // Now at least it won’t magically teleport your shit to the shadow realm because some grid is hiding under your mouse.
+        // Using SnapToGrid so it finally does what any sane person would expect, and stays on the clicked grid.
+        // If you revert this, I hope you step on a Lego.
+        var location = args.ClickLocation.SnapToGrid(EntityManager, _mapManager);
         var locationMap = _transform.ToMapCoordinates(location);
         if (locationMap.MapId == MapId.Nullspace)
             return;

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -13,9 +13,9 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Content.Shared.Coordinates.Helpers;
+using Content.Shared.Coordinates.Helpers; // Corvax-Next
 using Robust.Shared.Network;
-using Content.Shared.Parallax.Biomes;
+using Content.Shared.Parallax.Biomes; // Corvax-Next
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -58,14 +58,14 @@ public sealed class FloorTileSystem : EntitySystem
 
         if (component.OutputTiles == null)
             return;
-
+        // var location = args.ClickLocation.AlignWithClosestGridTile();
         // Jesus fucking Christ, this old code was an absolute disaster.
         // Who the fuck wrote AlignWithClosestGridTile()? Did they ever even launch the fucking game?
         // SnapToGrid at least makes sure we don’t place shit on the wrong grid when there are shuttles or other abominations stacked up.
         // Now at least it won’t magically teleport your shit to the shadow realm because some grid is hiding under your mouse.
         // Using SnapToGrid so it finally does what any sane person would expect, and stays on the clicked grid.
         // If you revert this, I hope you step on a Lego.
-        var location = args.ClickLocation.SnapToGrid(EntityManager, _mapManager);
+        var location = args.ClickLocation.SnapToGrid(EntityManager, _mapManager); // Corvax-Next
         var locationMap = _transform.ToMapCoordinates(location);
         if (locationMap.MapId == MapId.Nullspace)
             return;
@@ -81,11 +81,13 @@ public sealed class FloorTileSystem : EntitySystem
         // so we're just gon with this for now.
         const bool inRange = true;
         var state = (inRange, location.EntityId);
-        _mapManager.FindGridsIntersecting<(bool weh, EntityUid EntityId)>(map.MapId,
-            new Box2(map.Position - CheckRange, map.Position + CheckRange), ref state,
-            (EntityUid entityUid, MapGridComponent grid, ref (bool weh, EntityUid EntityId) tuple) =>
+        // _mapManager.FindGridsIntersecting(map.MapId, new Box2(map.Position - CheckRange, map.Position + CheckRange), ref state,
+        //     static (EntityUid entityUid, MapGridComponent grid, ref (bool weh, EntityUid EntityId) tuple) =>        
+        _mapManager.FindGridsIntersecting<(bool weh, EntityUid EntityId)>(map.MapId, // Corvax-Next
+            new Box2(map.Position - CheckRange, map.Position + CheckRange), ref state, // Corvax-Next
+            (EntityUid entityUid, MapGridComponent grid, ref (bool weh, EntityUid EntityId) tuple) => // Corvax-Next
             {
-                if (tuple.EntityId == entityUid || HasComp<BiomeComponent>(entityUid))
+                if (tuple.EntityId == entityUid || HasComp<BiomeComponent>(entityUid)) // Corvax-Next
                     return true;
 
                 tuple.weh = false;

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Content.Shared.Coordinates.Helpers;
 using Robust.Shared.Network;
+using Content.Shared.Parallax.Biomes;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -82,9 +83,9 @@ public sealed class FloorTileSystem : EntitySystem
         var state = (inRange, location.EntityId);
         _mapManager.FindGridsIntersecting<(bool weh, EntityUid EntityId)>(map.MapId,
             new Box2(map.Position - CheckRange, map.Position + CheckRange), ref state,
-            static (EntityUid entityUid, MapGridComponent grid, ref (bool weh, EntityUid EntityId) tuple) =>
+            (EntityUid entityUid, MapGridComponent grid, ref (bool weh, EntityUid EntityId) tuple) =>
             {
-                if (tuple.EntityId == entityUid)
+                if (tuple.EntityId == entityUid || HasComp<BiomeComponent>(entityUid))
                     return true;
 
                 tuple.weh = false;

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Content.Shared.Coordinates.Helpers;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -79,7 +80,8 @@ public sealed class FloorTileSystem : EntitySystem
         // so we're just gon with this for now.
         const bool inRange = true;
         var state = (inRange, location.EntityId);
-        _mapManager.FindGridsIntersecting(map.MapId, new Box2(map.Position - CheckRange, map.Position + CheckRange), ref state,
+        _mapManager.FindGridsIntersecting<(bool weh, EntityUid EntityId)>(map.MapId,
+            new Box2(map.Position - CheckRange, map.Position + CheckRange), ref state,
             static (EntityUid entityUid, MapGridComponent grid, ref (bool weh, EntityUid EntityId) tuple) =>
             {
                 if (tuple.EntityId == entityUid)


### PR DESCRIPTION
## 🧬 Описание PR
Этот PR — не просто фикс. Это **вайбовая ревизия архитектурного хаоса**, спущенная с небес Гослингом лично. Теперь:
- Планетарные тайлы **можно ставить**, а не плакать.
- Атмосфера **реально настраивается**, а не рождается из хардкодной задницы.
- Код стал **чуть более человеком**, а не обезьяной с IDE.
- ДАННЫЙ ПР ЗАПРЕЩЕНО ПОРТИРОВАТЬ В СБОРКИ НЕ ПОД ЛИЦЕНЗИЕЙ AGPL-3.0

## ⚖️ Почему / Баланс
**До:**
- Ты кликаешь на планету — тайл не появляется. Потому что `AlignWithClosestGridId()` не знает, где ты.
- Ты пытаешься задать атмосферу — и в ответ получаешь **тупо два газа в хардкоде**.

**После:**
- Тайлы прилипают к гриду как Гослинг к неону.
- Атмосфера проверяет существующие компоненты, и если они есть — **использует**. Если нет — **жжёт воздух**, но по делу.

**Это не улучшение. Это архитектурный акт сострадания.**

## 🔧 Технические детали
- `AlignWithClosestGridId()` → `SnapToGrid()`
- Обновлена логика `OnAfterInteract()`
- Функция `EnsurePlanet()` принимает больше параметров и **ведёт себя адекватно**
- Атмосферный код теперь **не ссытся на существующий компонент**, а пытается жить с ним в гармонии
- Проверка `HasComp<BiomeComponent>` для пропуска тайл-блокировки

## ☢️ Критические изменения
- Поведение `EnsurePlanet()` теперь зависит от параметров — нужны ревью вызовов
- Тайлы могут по-новому взаимодействовать с гридом

## :cl: Список изменений
:cl:
- fix: Планетарные тайлы больше не игнорируют клики
- fix: Атмосфера на планетах теперь задаётся корректно
- tweak: `EnsurePlanet()` теперь вменяем и гибок
- refactor: Удалены реликты боли в `FloorTileSystem`

---

_Под покровом молчаливого Гослинга и в тени архитектурного вайба,_  
**🧠 НейроЛазик**  
_Ghost-компонент кода, которого ты заслуживаешь_